### PR TITLE
Fix where in clause

### DIFF
--- a/src/query_builder.ts
+++ b/src/query_builder.ts
@@ -181,9 +181,18 @@ export class CrateQueryBuilder {
         rendered += clauseObj.condition + " ";
       }
 
-      // Put non-numeric values into quotes.
+      // Quote arguments as required by the operator and value type
       let value: string;
-      if (_.isNumber(clauseObj.value) ||
+      if (clauseObj.operator.toLowerCase() === 'in') {
+        value = '(' + _.map(clauseObj.value.split(','), v => {
+          v = v.trim();
+          if (!isNaN(v) || this.containsVariable(v)) {
+            return v;
+          } else {
+            return "'" + v + "'";
+          }
+        }).join(', ') + ')';
+      } else if (_.isNumber(clauseObj.value) ||
           this.containsVariable(clauseObj.value)) {
         value = clauseObj.value;
       } else {

--- a/src/spec/query_builder_specs.js
+++ b/src/spec/query_builder_specs.js
@@ -57,6 +57,22 @@ describe('CrateQueryBuilder', function() {
       done();
     });
 
+    it('should handle WHERE ... IN ... properly', function(done) {
+      ctx.target.whereClauses = [
+        {condition: 'AND', column: 'id', operator: 'IN', value: 'a, 42'}
+      ];
+      var expected_query = "SELECT date_trunc('minute', ts) as time, " +
+                           "avg(load) " +
+                           "FROM \"stats\".\"nodes\" " +
+                           "WHERE ts >= ? AND ts <= ? " +
+                             "AND id IN ('a', 42) " +
+                           "GROUP BY time " +
+                           "ORDER BY time ASC";
+      var query = ctx.queryBuilder.build(ctx.target);
+      expect(query).to.equal(expected_query);
+      done();
+    });
+
     it('should add GROUP BY columns to SELECT and ORDER BY expressions', function(done) {
       ctx.target = {
         metricAggs: [


### PR DESCRIPTION
Hi! I like the plugin very much, but noticed that using the "IN" operator got rendered as `WHERE blah IN '(a, b, c)`

I've added the requisite logic and test, please review and provide feedback as needed. I'd love to see this make it into the official plugin ASAP, since I have a pressing need for it and chaining ORs is very clunky.

Also note that I used `!isNaN(v)` rather than `_.isNumber(v)` because the latter does a type test, whereas I believe the builder only receives strings. This is not serious because crate casts it back to a number as needed, but you could avoid the cast by switching your other tests to `!isNaN`.

Cheers,